### PR TITLE
ui: mejora en las vistas de creacion de usuario, prestámo y devolución

### DIFF
--- a/Proyecto/main.py
+++ b/Proyecto/main.py
@@ -1,4 +1,27 @@
 import flet as ft
+# ----------------------------------------------------
+# Integración opcional con *flet-material*             
+# ----------------------------------------------------
+try:
+    import flet_material as fm  # type: ignore
+
+    # Configurar un tema Material moderno
+    fm.Theme.set_theme(theme="blue")
+except ModuleNotFoundError:  # Entorno sin flet-material (p.ej. CI)
+    class _FMStub:  # noqa: D101
+        class Theme:  # noqa: D101
+            bgcolor = None
+
+            @staticmethod
+            def set_theme(*args, **kwargs):  # noqa: D401,D401
+                pass
+
+        class Buttons(ft.ElevatedButton):  # noqa: D101
+            def __init__(self, *_, title: str = "", **kw):
+                super().__init__(title or kw.pop("text", ""), **kw)
+
+    fm = _FMStub()  # type: ignore
+
 from database import get_db, create_tables
 from services import UserService, BicycleService, StationService, LoanService
 from models import (
@@ -37,6 +60,10 @@ class VeciRunApp:
         page.window_maximized = True
         page.window_resizable = True
         page.padding = 20
+
+        # Aplicar color de fondo del tema Material si existe
+        if getattr(fm.Theme, "bgcolor", None):
+            page.bgcolor = fm.Theme.bgcolor
 
         # Initialize database
         create_tables()

--- a/Proyecto/views/create_user.py
+++ b/Proyecto/views/create_user.py
@@ -1,5 +1,19 @@
 import flet as ft
 
+# ------------------------------------------
+# Integración opcional con *flet-material*
+# ------------------------------------------
+try:
+    import flet_material as fm  # type: ignore
+except ModuleNotFoundError:  # Entorno sin flet-material (p.ej. CI)
+    class _FMStub:  # noqa: D101
+        class Buttons(ft.ElevatedButton):  # noqa: D101
+            def __init__(self, *_, title: str = "", **kw):
+                # Alineamos la API con flet-material: se puede pasar `title` o `text`.
+                super().__init__(title or kw.pop("text", ""), **kw)
+
+    fm = _FMStub()  # type: ignore
+
 from models import UserRoleEnum, UserAffiliationEnum
 from services import UserService
 
@@ -23,66 +37,112 @@ class CreateUserView(View):
         # ------------------------
         # Campos del formulario
         # ------------------------
+        FIELD_W = 320
+
         self.cedula_field = ft.TextField(
             label="Cédula",
             hint_text="Ingrese la cédula",
-            width=300,
+            width=FIELD_W,
+            prefix_icon=ft.icons.BADGE,
         )
         self.name_field = ft.TextField(
             label="Nombre Completo",
             hint_text="Ingrese el nombre completo",
-            width=300,
+            width=FIELD_W,
+            prefix_icon=ft.icons.PERSON,
         )
         self.email_field = ft.TextField(
             label="Email",
             hint_text="Ingrese el email",
-            width=300,
+            width=FIELD_W,
+            prefix_icon=ft.icons.EMAIL,
         )
 
         self.affiliation_dropdown = ft.Dropdown(
             label="Afiliación",
-            width=300,
+            width=FIELD_W,
             options=[
                 ft.dropdown.Option("estudiante", "Estudiante"),
                 ft.dropdown.Option("docente", "Docente"),
                 ft.dropdown.Option("administrativo", "Administrativo"),
             ],
+            prefix_icon=ft.icons.APARTMENT,
         )
 
-        self.role_dropdown = ft.Dropdown(
-            label="Rol",
-            width=300,
-            options=[
-                ft.dropdown.Option("usuario", "Usuario"),
-                ft.dropdown.Option("operador", "Operador"),
-                ft.dropdown.Option("admin", "Administrador"),
-            ],
-            value="usuario",
-        )
 
-        self.result_text = ft.Text("", color=ft.colors.GREEN)
+        self.result_text = ft.Text("", color=ft.colors.GREEN, selectable=True)
 
-        create_button = ft.ElevatedButton(
-            "Crear Usuario",
+        # ------------------------
+        # Botón Crear (material o fallback)
+        # ------------------------
+        self.create_button = fm.Buttons(
+            title="Crear Usuario",
             on_click=self._create_user,
-            style=ft.ButtonStyle(color=ft.colors.WHITE, bgcolor=ft.colors.BLUE),
+            width=200,
+            height=48,
+        )
+
+        # Deshabilitar inicialmente hasta que el formulario esté completo
+        self.create_button.disabled = True
+        self.create_button.style = ft.ButtonStyle(color=ft.colors.WHITE, bgcolor=ft.colors.GREY_400)
+
+        # --------------------------------------------------
+        # Helper para habilitar / deshabilitar el botón
+        # --------------------------------------------------
+
+        def _update_create_button(_: ft.ControlEvent | None = None) -> None:  # noqa: D401
+            complete = bool(
+                self.cedula_field.value
+                and self.name_field.value
+                and self.email_field.value
+                and self.affiliation_dropdown.value
+            )
+            self.create_button.disabled = not complete
+            self.create_button.style = ft.ButtonStyle(
+                color=ft.colors.WHITE,
+                bgcolor=ft.colors.GREEN if complete else ft.colors.GREY_400,
+            )
+            page.update()
+
+        # Escuchar cambios en los campos
+        for fld in [
+            self.cedula_field,
+            self.name_field,
+            self.email_field,
+            self.affiliation_dropdown,
+        ]:
+            fld.on_change = _update_create_button
+
+        # ------------------------
+        # Construir layout usando Card
+        # ------------------------
+        form_controls = ft.Column(
+            [
+                self.cedula_field,
+                self.name_field,
+                self.email_field,
+                self.affiliation_dropdown,
+                ft.Container(height=10),
+                self.create_button,
+            ],
+            spacing=10,
+        )
+
+        form_card = ft.Card(
+            elevation=2,
+            content=ft.Container(content=form_controls, padding=20, width=FIELD_W + 40),
         )
 
         return ft.Column(
             [
                 ft.Text("Crear Nuevo Usuario", size=24, weight=ft.FontWeight.BOLD),
                 ft.Divider(),
-                self.cedula_field,
-                self.name_field,
-                self.email_field,
-                self.affiliation_dropdown,
-                self.role_dropdown,
-                ft.Container(height=20),
-                create_button,
+                ft.Row([form_card], alignment=ft.MainAxisAlignment.CENTER),
                 ft.Container(height=20),
                 self.result_text,
             ],
             scroll=ft.ScrollMode.AUTO,
+            spacing=10,
         )
 
     # ------------------------------------------------------------------
@@ -119,7 +179,7 @@ class CreateUserView(View):
                 full_name=self.name_field.value,
                 email=self.email_field.value,
                 affiliation=UserAffiliationEnum(self.affiliation_dropdown.value),
-                role=UserRoleEnum(self.role_dropdown.value),
+                role=UserRoleEnum("usuario"), # Hard-code role to 'usuario'
             )
 
             self._set_result(f"Usuario creado exitosamente: {user.full_name}", ft.colors.GREEN)
@@ -141,4 +201,7 @@ class CreateUserView(View):
         self.name_field.value = ""
         self.email_field.value = ""
         self.affiliation_dropdown.value = None
-        self.role_dropdown.value = "usuario"
+        # Deshabilitar botón hasta completar nuevamente el formulario
+        if hasattr(self, "create_button"):
+            self.create_button.disabled = True
+            self.create_button.style = ft.ButtonStyle(color=ft.colors.WHITE, bgcolor=ft.colors.GREY_400)

--- a/Proyecto/views/home.py
+++ b/Proyecto/views/home.py
@@ -52,20 +52,13 @@ class HomeView(View):
             focused_border_color=ft.colors.BLUE_400,
         )
 
+        # Contenedor más compacto para la estación (solo el dropdown con una etiqueta en el
+        # propio control). Esto reduce altura y evita necesidad de "scroll" al cambiar de rol.
+        station_dropdown.label = "Estación Asignada (solo administradores)"
+
         station_container = ft.Container(
-            content=ft.Column(
-                [
-                    ft.Text("Estación Asignada", size=16, weight=ft.FontWeight.BOLD),
-                    ft.Text(
-                        "(Requerido para administradores)",
-                        size=12,
-                        color=ft.colors.GREY_600,
-                    ),
-                    ft.Container(height=10),
-                    station_dropdown,
-                ]
-            ),
-            padding=ft.padding.only(bottom=20),
+            content=station_dropdown,
+            padding=ft.padding.only(bottom=10),
             visible=False,
         )
 
@@ -179,29 +172,21 @@ class HomeView(View):
                             text_align=ft.TextAlign.CENTER,
                             color=ft.colors.GREY_600,
                         ),
-                        ft.Container(height=25),
+                        ft.Container(height=15),
+                        # Contenedor solo con el selector de rol, centrado.
                         ft.Container(
-                            content=ft.Column(
-                                [
-                                    ft.Text(
-                                        "Seleccione su rol",
-                                        size=16,
-                                        weight=ft.FontWeight.BOLD,
-                                    ),
-                                    ft.Container(height=10),
-                                    role_dropdown,
-                                ]
-                            ),
-                            padding=ft.padding.only(bottom=20),
+                            content=role_dropdown,
+                            padding=ft.padding.only(bottom=10),
+                            alignment=ft.alignment.center,
                         ),
-                        ft.Container(content=cedula_field, padding=ft.padding.only(bottom=20)),
+                        ft.Container(content=cedula_field, padding=ft.padding.only(bottom=10)),
                         station_container,
-                        ft.Container(content=sign_in_button, padding=ft.padding.only(top=20)),
-                        ft.Container(content=status_text, padding=ft.padding.only(top=15)),
+                        ft.Container(content=sign_in_button, padding=ft.padding.only(top=10)),
+                        ft.Container(content=status_text, padding=ft.padding.only(top=10)),
                     ],
                     horizontal_alignment=ft.CrossAxisAlignment.CENTER,
                 ),
-                padding=40,
+                padding=20,
                 width=450,
             ),
             elevation=8,

--- a/Proyecto/views/loan.py
+++ b/Proyecto/views/loan.py
@@ -1,5 +1,20 @@
 import flet as ft
 
+# -----------------------------
+# Integración opcional flet-material
+# -----------------------------
+try:
+    import flet_material as fm  # type: ignore
+except ModuleNotFoundError:  # Entorno sin flet-material
+    from types import SimpleNamespace
+
+    class _FMStub:  # noqa: D101
+        class Buttons(ft.ElevatedButton):  # noqa: D101
+            def __init__(self, *_, title: str = "", **kw):
+                super().__init__(title or kw.pop("text", ""), **kw)
+
+    fm = _FMStub()  # type: ignore
+
 from services import (
     UserService,
     BicycleService,
@@ -23,10 +38,13 @@ class LoanView(View):
         # -----------------------
         # Campos del formulario
         # -----------------------
+        FIELD_WIDTH = 450
+
         user_cedula = ft.TextField(
             label="Cédula del Usuario",
             hint_text="Ingrese la cédula del usuario",
-            width=300,
+            width=FIELD_WIDTH,
+            prefix_icon=ft.icons.BADGE,
         )
 
         station_opts = [
@@ -37,12 +55,33 @@ class LoanView(View):
             ft.dropdown.Option("EST005", "EST005 - Edificio Ciencia y Tecnología"),
         ]
 
-        station_out = ft.Dropdown(label="Estación de Salida", width=300, options=station_opts)
+        # Estación asignada al administrador en sesión (valor fijo)
+        current_station = getattr(self.app, "current_user_station", None)
+
+        # Dropdown de estación de salida: valor fijo y deshabilitado para admins
+        station_out = ft.Dropdown(
+            label="Estación de Salida",
+            width=FIELD_WIDTH,
+            options=station_opts,
+            value=current_station,
+            disabled=True,
+            prefix_icon=ft.icons.TRANSFER_WITHIN_A_STATION,
+            dense=True,
+        )
+
+        # Opciones de estación de llegada excluyendo la estación de salida
+        station_in_opts = (
+            [opt for opt in station_opts if opt.key != current_station]
+            if current_station
+            else station_opts
+        )
         station_in = ft.Dropdown(
             label="Estación de Llegada",
-            width=300,
-            options=station_opts,
-            disabled=True,
+            width=FIELD_WIDTH,
+            options=station_in_opts,
+            disabled=current_station is None,
+            prefix_icon=ft.icons.LOCATION_ON,
+            dense=True,
         )
 
         # --- Sincronizar dropdowns ---
@@ -50,24 +89,84 @@ class LoanView(View):
             out_val = station_out.value
             if not out_val:
                 station_in.disabled = True
-                station_in.options = station_opts
+                station_in.options = station_in_opts
             else:
                 station_in.disabled = False
-                station_in.options = [opt for opt in station_opts if opt.key != out_val]
+                station_in.options = [opt for opt in station_in_opts if opt.key != out_val]
                 if station_in.value == out_val:
                     station_in.value = None
             page.update()
 
         station_out.on_change = _update_station_in
 
+        # --- Vincular actualizaciones de estado ---
+        station_in.on_change = lambda e: _update_save_button()
+        user_cedula.on_change = lambda e: _update_save_button()
+
         available_bikes = BicycleService.get_available_bicycles(db)
-        bike_radio = ft.RadioGroup(
-            content=ft.Column(
-                [
-                    ft.Radio(value=b.bike_code, label=f"{b.bike_code} - {b.serial_number}")
-                    for b in available_bikes
-                ]
+        # -----------------------------
+        # Selección de bicicleta (cards)
+        # -----------------------------
+
+        selected_bike: dict[str, str | None] = {"code": None}
+
+        bike_card_map: dict[str, ft.Card] = {}
+
+        def _make_bike_select_handler(code: str):
+            """Genera handler de click para seleccionar bicicleta."""
+
+            def _handler(_: ft.ControlEvent) -> None:  # noqa: D401
+                # Guardar selección
+                selected_bike["code"] = code
+
+                # Actualizar estado visual de todas las tarjetas
+                for c_code, card in bike_card_map.items():
+                    is_selected = c_code == code
+                    card.elevation = 8 if is_selected else 1
+                    card.content.bgcolor = ft.colors.BLUE_50 if is_selected else ft.colors.GREY_100
+                page.update()
+                _update_save_button()
+
+            return _handler
+
+        bike_cards: list[ft.Card] = []
+        CARD_W, CARD_H = 110, 110  # un poco más grande y legible
+
+        for bike in available_bikes:
+            card = ft.Card(
+                elevation=1,
+                content=ft.Container(
+                    width=CARD_W,
+                    height=CARD_H,
+                    bgcolor=ft.colors.GREY_100,
+                    border_radius=8,
+                    padding=8,
+                    alignment=ft.alignment.center,
+                    on_click=_make_bike_select_handler(bike.bike_code),
+                    content=ft.Column(
+                        [
+                            ft.Icon(ft.icons.DIRECTIONS_BIKE, size=24, color=ft.colors.BLUE_700),
+                            ft.Text(
+                                bike.bike_code,
+                                weight=ft.FontWeight.BOLD,
+                                size=13,
+                            ),
+                        ],
+                        horizontal_alignment=ft.CrossAxisAlignment.CENTER,
+                        spacing=4,
+                    ),
+                    tooltip=f"Serie: {bike.serial_number}",
+                    ink=True,
+                ),
             )
+            bike_card_map[bike.bike_code] = card
+            bike_cards.append(card)
+
+        bikes_grid = ft.Row(
+            controls=bike_cards,
+            wrap=True,
+            spacing=8,
+            run_spacing=8,
         )
 
         result_text = ft.Text("", color=ft.colors.GREEN)
@@ -77,14 +176,12 @@ class LoanView(View):
         # -------------------
         def _register(_: ft.ControlEvent) -> None:  # noqa: D401
             # Validaciones
-            if not all(
-                [
-                    user_cedula.value,
-                    bike_radio.value,
-                    station_out.value,
-                    station_in.value,
-                ]
-            ):
+            if not all([
+                user_cedula.value,
+                selected_bike["code"],
+                station_out.value,
+                station_in.value,
+            ]):
                 _set_result("Todos los campos son obligatorios", ft.colors.RED)
                 return
             if station_out.value == station_in.value:
@@ -98,7 +195,7 @@ class LoanView(View):
             if not user:
                 _set_result("Usuario no encontrado", ft.colors.RED)
                 return
-            bike = BicycleService.get_bicycle_by_code(db, bike_radio.value)
+            bike = BicycleService.get_bicycle_by_code(db, selected_bike["code"])
             if not bike:
                 _set_result("Bicicleta no encontrada", ft.colors.RED)
                 return
@@ -119,18 +216,68 @@ class LoanView(View):
             _set_result("Préstamo registrado exitosamente", ft.colors.GREEN)
             # Limpiar campos
             user_cedula.value = ""
-            station_out.value = station_in.value = None
-            bike_radio.value = None
+            station_in.value = None  # station_out permanece fijo
+
+            # Reset selección de bicicleta
+            selected_bike["code"] = None
+            for card in bike_card_map.values():
+                card.elevation = 1
+                card.content.bgcolor = ft.colors.GREY_100
+
             page.update()
+            _update_save_button()
 
         def _set_result(msg: str, color: str) -> None:
             result_text.value = msg
             result_text.color = color
 
-        save_btn = ft.ElevatedButton(
-            "Registrar Préstamo",
+        save_btn = fm.Buttons(
+            title="Registrar Préstamo",
             on_click=_register,
-            style=ft.ButtonStyle(color=ft.colors.WHITE, bgcolor=ft.colors.GREEN),
+            width=240,
+            height=48,
+        )
+
+        # Deshabilitado hasta que el formulario esté completo
+        save_btn.disabled = True
+        save_btn.style = ft.ButtonStyle(color=ft.colors.WHITE, bgcolor=ft.colors.GREY_400)
+
+        # ---------------------------------------
+        # Helper para habilitar / deshabilitar botón
+        # ---------------------------------------
+
+        def _update_save_button() -> None:  # noqa: D401
+            complete = bool(
+                user_cedula.value
+                and selected_bike["code"]
+                and station_out.value
+                and station_in.value
+                and station_out.value != station_in.value
+            )
+            save_btn.disabled = not complete
+            save_btn.style = ft.ButtonStyle(
+                color=ft.colors.WHITE,
+                bgcolor=ft.colors.GREEN if complete else ft.colors.GREY_400,
+            )
+            page.update()
+
+        form_controls = ft.Column(
+            [
+                user_cedula,
+                station_out,
+                station_in,
+                ft.Container(height=10),
+                save_btn,
+            ],
+            spacing=10,
+        )
+
+        bikes_section = ft.Column(
+            [
+                ft.Text("Seleccione una bicicleta", size=16, weight=ft.FontWeight.BOLD),
+                ft.Container(height=8),
+                bikes_grid,
+            ]
         )
 
         return ft.Column(
@@ -141,15 +288,22 @@ class LoanView(View):
                     weight=ft.FontWeight.BOLD,
                 ),
                 ft.Divider(),
-                user_cedula,
-                station_out,
-                station_in,
-                ft.Container(height=20),
-                bike_radio,
-                ft.Container(height=20),
-                save_btn,
+                ft.Row(
+                    [
+                        ft.Card(content=ft.Container(content=form_controls, padding=15, width=FIELD_WIDTH+40)),
+                        ft.Container(width=20),
+                        ft.Container(
+                            expand=True,
+                            content=ft.Card(
+                                content=ft.Container(content=bikes_section, padding=15),
+                            ),
+                        ),
+                    ],
+                    vertical_alignment=ft.CrossAxisAlignment.START,
+                ),
                 ft.Container(height=20),
                 result_text,
             ],
             scroll=ft.ScrollMode.AUTO,
+            spacing=10,
         )

--- a/Proyecto/views/return_view.py
+++ b/Proyecto/views/return_view.py
@@ -1,5 +1,18 @@
 import flet as ft
 
+# ------------------------------------------------------------------
+# Integración opcional con *flet-material* para un look más moderno
+# ------------------------------------------------------------------
+try:
+    import flet_material as fm  # type: ignore
+except ModuleNotFoundError:  # Entorno sin flet-material (p.ej. CI)
+    class _FMStub:  # noqa: D101
+        class Buttons(ft.ElevatedButton):  # noqa: D101
+            def __init__(self, *_, title: str = "", **kw):
+                super().__init__(title or kw.pop("text", ""), **kw)
+
+    fm = _FMStub()  # type: ignore
+
 from services import UserService, StationService, LoanService
 
 from .base import View
@@ -15,15 +28,21 @@ class ReturnView(View):
         page = self.app.page
         db = self.app.db
 
+        # ------------------------------------------------------------------
+        # Campos del formulario
+        # ------------------------------------------------------------------
+        FIELD_WIDTH = 450
+
         user_cedula = ft.TextField(
             label="Cédula del Usuario",
             hint_text="Ingrese la cédula del usuario",
-            width=300,
+            width=FIELD_WIDTH,
+            prefix_icon=ft.icons.BADGE,
         )
 
         station_dropdown = ft.Dropdown(
             label="Estación de Devolución",
-            width=300,
+            width=FIELD_WIDTH,
             options=[
                 ft.dropdown.Option("EST001", "EST001 - Calle 26"),
                 ft.dropdown.Option("EST002", "EST002 - Salida al Uriel Gutiérrez"),
@@ -31,6 +50,8 @@ class ReturnView(View):
                 ft.dropdown.Option("EST004", "EST004 - Calle 45"),
                 ft.dropdown.Option("EST005", "EST005 - Edificio Ciencia y Tecnología"),
             ],
+            prefix_icon=ft.icons.LOCATION_ON,
+            dense=True,
         )
 
         result_text = ft.Text("", color=ft.colors.GREEN)
@@ -58,16 +79,49 @@ class ReturnView(View):
             user_cedula.value = ""
             station_dropdown.value = None
             page.update()
+            _update_save_button()
 
         def _set_result(msg: str, color: str) -> None:
             result_text.value = msg
             result_text.color = color
 
-        save_btn = ft.ElevatedButton(
-            "Registrar Devolución",
-            icon=ft.icons.ASSIGNMENT_RETURN,
+        # ------------------------------------------------------------------
+        # Botón estilizado (usa flet-material si está disponible)
+        # ------------------------------------------------------------------
+
+        save_btn = fm.Buttons(
+            title="Registrar Devolución",
             on_click=_register,
-            style=ft.ButtonStyle(color=ft.colors.WHITE, bgcolor=ft.colors.ORANGE),
+            icon=ft.icons.ASSIGNMENT_RETURN,
+            width=240,
+            height=48,
+        )
+
+        # Deshabilitado hasta que el formulario esté completo
+        save_btn.disabled = True
+        save_btn.style = ft.ButtonStyle(color=ft.colors.WHITE, bgcolor=ft.colors.GREY_400)
+
+        # ---------------------------------------
+        # Helper para habilitar / deshabilitar botón
+        # ---------------------------------------
+
+        def _update_save_button(_: ft.ControlEvent | None = None) -> None:  # noqa: D401
+            complete = bool(user_cedula.value and station_dropdown.value)
+            save_btn.disabled = not complete
+            save_btn.style = ft.ButtonStyle(
+                color=ft.colors.WHITE,
+                bgcolor=ft.colors.GREEN if complete else ft.colors.GREY_400,
+            )
+            page.update()
+
+        # Vincular cambios para habilitar boton
+        user_cedula.on_change = _update_save_button
+        station_dropdown.on_change = _update_save_button
+
+        # Agrupar controles en un *Card* para mejor estética
+        form_controls = ft.Column(
+            [user_cedula, station_dropdown, ft.Container(height=10), save_btn],
+            spacing=10,
         )
 
         return ft.Column(
@@ -78,12 +132,12 @@ class ReturnView(View):
                     weight=ft.FontWeight.BOLD,
                 ),
                 ft.Divider(),
-                user_cedula,
-                station_dropdown,
-                ft.Container(height=20),
-                save_btn,
+                ft.Card(
+                    content=ft.Container(content=form_controls, padding=15, width=FIELD_WIDTH + 40),
+                ),
                 ft.Container(height=20),
                 result_text,
             ],
             scroll=ft.ScrollMode.AUTO,
+            spacing=10,
         )


### PR DESCRIPTION
En esta rama, se realizaron mejoras significativas en la interfaz de usuario para las vistas de préstamo y devolución de bicicletas. Se integró opcionalmente el paquete flet-material para proporcionar un aspecto más moderno y consistente. Los formularios ahora están encapsulados en componentes Card con iconos de prefijo y un ancho uniforme de 450 px para mejorar la claridad visual. Los botones de acción se actualizan dinámicamente, habilitándose solo cuando el formulario está completo, y cambian de color para indicar su estado. Estas mejoras aseguran una experiencia de usuario más intuitiva y visualmente atractiva.