### PR TITLE
Registrar prestamo improve

### DIFF
--- a/Proyecto/services.py
+++ b/Proyecto/services.py
@@ -11,6 +11,10 @@ from models import (
 )
 from datetime import datetime
 import uuid
+from datetime import timezone, timedelta
+
+# Zona horaria de Colombia (UTC-5)
+CO_TZ = timezone(timedelta(hours=-5))
 
 
 class UserService:
@@ -94,13 +98,14 @@ class LoanService:
         station_in_id: uuid.UUID | None = None,
     ) -> Loan:
         """Register a loan (bike check-out)"""
-        # Create the loan
+        # Create the loan con timestamp en hora local de Colombia
         loan = Loan(
             user_id=user_id,
             bike_id=bike_id,
             station_out_id=station_out_id,
             station_in_id=station_in_id,
             status=LoanStatusEnum.abierto,
+            time_out=datetime.now(CO_TZ),
         )
         db.add(loan)
 
@@ -125,7 +130,7 @@ class LoanService:
 
         # Update loan
         loan.station_in_id = station_in_id
-        loan.time_in = datetime.utcnow()
+        loan.time_in = datetime.now(CO_TZ)
         loan.status = LoanStatusEnum.cerrado
 
         # Update bicycle status back to 'disponible'

--- a/Proyecto/tests/test_ui_loan_station_filter.py
+++ b/Proyecto/tests/test_ui_loan_station_filter.py
@@ -1,0 +1,112 @@
+import types
+import flet as ft
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import database  # noqa: F401 – needed to patch SessionLocal
+
+from models import Base, Station, Bicycle, BikeStatusEnum
+
+# -------------------------------------------------
+#   Stub de ElevatedButton (igual al usado en tests/test_ui_loan.py)
+# -------------------------------------------------
+
+
+class _DummyElevatedButton:  # noqa: D101
+    last_callback = None
+
+    def __init__(self, *_, on_click=None, **__):  # noqa: D401
+        self.on_click = on_click
+        _DummyElevatedButton.last_callback = on_click
+
+
+# Parchar antes de importar la app principal para que cualquier referencia
+# use el stub y evitemos dependencias de Flet en los tests.
+ft.ElevatedButton = _DummyElevatedButton  # type: ignore
+
+from main import VeciRunApp  # noqa: E402  (import después de parchar)
+
+
+def _extract_text_values(ctrl):  # noqa: D401
+    """Recorre un árbol de controles Flet y extrae los valores de *ft.Text*."""
+    import flet as _ft  # Importación local para evitar problemas de orden
+
+    texts: list[str] = []
+    if isinstance(ctrl, _ft.Text):
+        # Algunos textos relevantes están en ``value`` y otros en ``text``
+        val = getattr(ctrl, "value", None) or getattr(ctrl, "text", None)
+        if isinstance(val, str):
+            texts.append(val)
+
+    # Explorar atributos típicos que contienen hijos
+    for attr in ("controls", "content"):
+        if hasattr(ctrl, attr):
+            child = getattr(ctrl, attr)
+            if child is None:
+                continue
+            if isinstance(child, list):
+                for c in child:
+                    texts.extend(_extract_text_values(c))
+            else:
+                texts.extend(_extract_text_values(child))
+    return texts
+
+
+def test_loan_view_filters_bikes_by_admin_station():  # noqa: D401
+    """LoanView solo debe mostrar bicicletas cuya estación coincide con la asignada."""
+
+    # ------------------------------
+    # Preparar BD en memoria
+    # ------------------------------
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    db = TestingSessionLocal()
+
+    # Crear estaciones
+    est1 = Station(code="EST001", name="Calle 26")
+    est2 = Station(code="EST002", name="Otra")
+    db.add_all([est1, est2])
+    db.commit()
+
+    # Crear bicicletas disponibles en ambas estaciones
+    bike1 = Bicycle(
+        serial_number="S001",
+        bike_code="B001",
+        status=BikeStatusEnum.disponible,
+        current_station=est1,
+    )
+    bike2 = Bicycle(
+        serial_number="S002",
+        bike_code="B002",
+        status=BikeStatusEnum.disponible,
+        current_station=est2,
+    )
+    db.add_all([bike1, bike2])
+    db.commit()
+
+    # Parchear el SessionLocal usado por el proyecto
+    database.SessionLocal = TestingSessionLocal  # type: ignore
+
+    # ------------------------------
+    # Inicializar la app y vista
+    # ------------------------------
+    app = VeciRunApp()
+    app.db = db  # Reemplazar la sesión por la de pruebas
+    app.current_user_station = "EST001"  # Simular admin en estación EST001
+
+    # Dummy page para métodos update()
+    dummy_page = types.SimpleNamespace(update=lambda *_, **__: None)
+    app.content_area = types.SimpleNamespace(content=None)
+
+    # Renderizar la vista de préstamo
+    app.refresh_loan_view(dummy_page)
+
+    # Extraer los códigos de bicicletas mostrados en la UI
+    loan_view_control = app.content_area.content
+    text_values = _extract_text_values(loan_view_control)
+
+    # Filtrar posibles textos que sean códigos de bicicleta ("B###")
+    bike_codes_in_ui = {t for t in text_values if t.startswith("B")}
+
+    assert "B001" in bike_codes_in_ui, "La bicicleta de la estación asignada debe mostrarse"
+    assert "B002" not in bike_codes_in_ui, "Las bicicletas de otras estaciones no deben mostrarse" 


### PR DESCRIPTION
## Descripción de cambios
### Filtrado de bicicletas en registrar préstamo:
La vista de registro de préstamo ahora solo muestra las bicicletas disponibles cuya estación actual coincide con la estación asignada al administrador que inició sesión. Esto mejora la precisión y evita errores operativos.
### Soporte de zona horaria Colombia (GMT-5):
Los timestamps de registro y devolución de préstamos ahora se almacenan usando la hora local de Colombia, en vez de UTC.
### Pruebas automáticas:
Se añadió un test de UI que verifica que la vista de préstamo solo muestre bicicletas de la estación correspondiente al administrador.
### Mejoras de compatibilidad para tests:
Se ajustó la lógica interna para asegurar que los tests unitarios puedan acceder correctamente al callback del botón de registrar préstamo, independientemente de la implementación de Flet o Flet-Material.