### PR TITLE
Restricción: solo un préstamo activo por usuario

### DIFF
--- a/Proyecto/views/loan.py
+++ b/Proyecto/views/loan.py
@@ -210,6 +210,15 @@ class LoanView(View):
             if not user:
                 _set_result("Usuario no encontrado", ft.colors.RED)
                 return
+
+            # ==============================
+            # NUEVA VALIDACIÓN:
+            # ==============================
+            open_loans = LoanService.get_open_loans_by_user(db, user.id)
+            if open_loans:
+                _set_result("El usuario ya tiene un préstamo activo y no puede registrar otro.", ft.colors.RED)
+                return
+
             bike = BicycleService.get_bicycle_by_code(db, selected_bike["code"])
             if not bike:
                 _set_result("Bicicleta no encontrada", ft.colors.RED)


### PR DESCRIPTION
Se implementa la validación para impedir que un usuario registre más de un préstamo activo. Si ya tiene un préstamo abierto, se muestra un mensaje de error y no se permite registrar uno nuevo.
