### PR TITLE
Agregar una bicicleta favorita

### DIFF
--- a/Proyecto/FAVORITE_BIKE_FEATURE.md
+++ b/Proyecto/FAVORITE_BIKE_FEATURE.md
@@ -1,0 +1,135 @@
+# Funcionalidad de Bicicletas Favoritas
+
+## Descripción
+
+Se ha implementado una nueva funcionalidad que permite a los usuarios elegir una bicicleta favorita entre las que han usado anteriormente en sus préstamos. Esta funcionalidad incluye reglas específicas para garantizar un uso justo y organizado del sistema.
+
+## Reglas Implementadas
+
+### 1. Una sola bicicleta favorita por usuario
+- Cada usuario solo puede tener una bicicleta marcada como favorita
+- Si el usuario ya tiene una bicicleta favorita y elige otra, la anterior se reemplaza automáticamente
+
+### 2. Solo bicicletas usadas anteriormente
+- Los usuarios solo pueden elegir como favorita una bicicleta que hayan usado en préstamos anteriores o en curso
+- El sistema verifica el historial de préstamos del usuario antes de permitir la selección
+
+### 3. Exclusividad de bicicletas favoritas
+- Una bicicleta que ha sido marcada como favorita por un usuario no puede ser elegida como favorita por otro usuario
+- Solo cuando el propietario actual quita la bicicleta de sus favoritos, otro usuario puede elegirla
+
+### 4. Información visible para administradores
+- Cuando un administrador registra un préstamo, puede ver qué bicicletas son favoritas de otros usuarios
+- Las bicicletas favoritas se muestran con un ícono de corazón y fondo rosado
+- Se incluye información del propietario en el tooltip de la bicicleta
+
+### 5. Información en el perfil del usuario
+- Los usuarios pueden ver en su dashboard la información de su bicicleta favorita
+- Se muestra la estación donde se encuentra actualmente la bicicleta favorita
+- Se incluye el estado actual de la bicicleta
+
+## Componentes Implementados
+
+### Servicios (`services.py`)
+
+Se agregó la clase `FavoriteBikeService` con los siguientes métodos:
+
+- `get_user_favorite_bike(db, user_id)`: Obtiene la bicicleta favorita de un usuario
+- `get_user_favorite_bike_by_cedula(db, cedula)`: Obtiene la bicicleta favorita por cédula
+- `get_bikes_used_by_user(db, user_id)`: Obtiene todas las bicicletas que ha usado un usuario
+- `get_bikes_used_by_user_cedula(db, cedula)`: Obtiene bicicletas usadas por cédula
+- `set_favorite_bike(db, user_id, bike_id)`: Establece una bicicleta como favorita
+- `set_favorite_bike_by_cedula(db, cedula, bike_id)`: Establece favorita por cédula
+- `remove_favorite_bike(db, user_id)`: Quita la bicicleta favorita
+- `remove_favorite_bike_by_cedula(db, cedula)`: Quita favorita por cédula
+- `get_favorite_bike_owner(db, bike_id)`: Obtiene el propietario de una bicicleta favorita
+- `is_bike_favorite(db, bike_id)`: Verifica si una bicicleta es favorita de alguien
+
+### Vista de Gestión (`views/favorite_bike.py`)
+
+Nueva vista `FavoriteBikeView` que permite a los usuarios:
+
+- Ver su bicicleta favorita actual
+- Ver todas las bicicletas que han usado y pueden elegir como favorita
+- Establecer una nueva bicicleta como favorita
+- Quitar su bicicleta favorita actual
+- Ver información detallada de cada bicicleta (estación, estado, etc.)
+
+### Modificaciones en Vistas Existentes
+
+#### Vista de Préstamos (`views/loan.py`)
+- Se agregó información visual para bicicletas favoritas
+- Las bicicletas favoritas se muestran con ícono de corazón y fondo rosado
+- Se incluye información del propietario en el tooltip
+
+#### Dashboard (`views/dashboard.py`)
+- Se agregó información de la bicicleta favorita en el perfil del usuario
+- Se muestra la ubicación y estado de la bicicleta favorita
+- Se agregó opción en el menú para gestionar bicicletas favoritas
+
+### Navegación (`main.py`)
+- Se agregó nueva opción "Mi Favorita" en el menú de usuarios regulares
+- Se integró la nueva vista en el sistema de navegación
+
+## Uso de la Funcionalidad
+
+### Para Usuarios Regulares
+
+1. **Acceder a la gestión de favoritas**: En el menú lateral, seleccionar "Mi Favorita"
+2. **Ver bicicleta favorita actual**: La vista muestra si el usuario tiene una bicicleta favorita y su información
+3. **Elegir nueva bicicleta favorita**: 
+   - Ver la lista de bicicletas usadas anteriormente
+   - Seleccionar una bicicleta disponible (no favorita de otro usuario)
+   - Hacer clic en "Elegir como favorita"
+4. **Quitar bicicleta favorita**: Hacer clic en "Quitar Bicicleta Favorita"
+
+### Para Administradores
+
+1. **Ver información de favoritas**: Al registrar préstamos, las bicicletas favoritas se muestran con:
+   - Ícono de corazón rojo
+   - Fondo rosado
+   - Tooltip con información del propietario
+2. **Tomar decisiones informadas**: Conocer qué bicicletas son favoritas de usuarios específicos
+
+## Validaciones Implementadas
+
+- **Verificación de uso previo**: Solo se pueden elegir bicicletas que el usuario haya usado
+- **Exclusividad**: Una bicicleta no puede ser favorita de múltiples usuarios
+- **Existencia de usuario**: Se verifica que el usuario exista antes de realizar operaciones
+- **Estado de bicicleta**: Se considera el estado actual de la bicicleta al mostrar información
+
+## Base de Datos
+
+La funcionalidad utiliza el campo `favorite_bike_id` que ya existía en el modelo `User`:
+
+```python
+class User(Base):
+    # ... otros campos ...
+    favorite_bike_id = Column(UUID(as_uuid=True), ForeignKey("bicycles.id"))
+    favorite_bike = relationship("Bicycle", foreign_keys=[favorite_bike_id])
+```
+
+## Pruebas
+
+Se incluye un script de prueba (`test_favorite_bike.py`) que demuestra:
+
+- Creación de datos de prueba
+- Establecimiento de bicicletas favoritas
+- Validación de reglas de exclusividad
+- Verificación de restricciones de uso previo
+- Funcionalidad de quitar bicicletas favoritas
+
+## Consideraciones Técnicas
+
+- **Rendimiento**: Las consultas están optimizadas para evitar N+1 queries
+- **Integridad**: Se mantiene la integridad referencial en la base de datos
+- **UX**: Interfaz intuitiva con feedback visual claro
+- **Escalabilidad**: La implementación permite futuras expansiones de la funcionalidad
+
+## Futuras Mejoras Posibles
+
+- Notificaciones cuando la bicicleta favorita esté disponible
+- Historial de bicicletas favoritas
+- Estadísticas de uso de bicicletas favoritas
+- Integración con sistema de reservas
+- Reportes de bicicletas favoritas por estación 

--- a/Proyecto/main.py
+++ b/Proyecto/main.py
@@ -44,6 +44,7 @@ from views.loan import LoanView
 from views.return_view import ReturnView
 from views.current_loan import CurrentLoanView
 from views.loan_history import LoanHistoryView
+from views.favorite_bike import FavoriteBikeView
 from typing import Callable, Dict
 
 # noqa: F401 needed for typing
@@ -184,11 +185,17 @@ class VeciRunApp:
                     selected_icon=ft.icons.DIRECTIONS_BIKE,
                     label="Mi Préstamo",
                 ),
+                ft.NavigationRailDestination(
+                    icon=ft.icons.FAVORITE,
+                    selected_icon=ft.icons.FAVORITE,
+                    label="Mi Favorita",
+                ),
             ]
 
             # Índices coherentes con las posiciones de *destinations*
             self.view_registry[1] = lambda: AvailabilityView(self)
             self.view_registry[2] = lambda: CurrentLoanView(self)
+            self.view_registry[3] = lambda: FavoriteBikeView(self)
 
         self.nav_rail.destinations = destinations
         self.page.update()

--- a/Proyecto/views/favorite_bike.py
+++ b/Proyecto/views/favorite_bike.py
@@ -1,0 +1,359 @@
+import flet as ft
+from services import FavoriteBikeService, UserService
+from models import UserRoleEnum
+from .base import View
+
+
+class FavoriteBikeView(View):
+    """Vista para gestionar bicicletas favoritas de usuarios."""
+
+    def __init__(self, app: "VeciRunApp") -> None:  # noqa: F821
+        self.app = app
+        self.current_user = getattr(self.app, "current_user", None)
+        self.current_user_cedula = self.current_user.cedula if self.current_user else None
+
+    def build(self) -> ft.Control:
+        page = self.app.page
+        db = self.app.db
+
+        # Verificar si hay un usuario logueado
+        if not self.current_user:
+            return ft.Column(
+                [
+                    ft.Container(height=50),
+                    ft.Text(
+                        "Debe iniciar sesión para acceder a esta funcionalidad",
+                        size=20,
+                        weight=ft.FontWeight.BOLD,
+                        color=ft.colors.RED_700,
+                    ),
+                    ft.Container(height=20),
+                    ft.ElevatedButton(
+                        text="Ir al Inicio",
+                        icon=ft.icons.HOME,
+                        on_click=lambda e: self.app.show_dashboard_view(),
+                    ),
+                ],
+                horizontal_alignment=ft.CrossAxisAlignment.CENTER,
+            )
+        page = self.app.page
+        db = self.app.db
+
+        # Título de la página
+        title = ft.Text(
+            "Mi Bicicleta Favorita",
+            size=24,
+            weight=ft.FontWeight.BOLD,
+            color=ft.colors.BLUE_900,
+        )
+
+        # Información del usuario actual
+        user_info = ft.Text(
+            f"Usuario: {self.current_user.full_name} - Cédula: {self.current_user.cedula}",
+            size=16,
+            weight=ft.FontWeight.BOLD,
+            color=ft.colors.GREY_700,
+        )
+
+        # Contenedor para mostrar la bicicleta favorita actual
+        self.favorite_bike_container = ft.Container(
+            padding=20,
+            content=ft.Text("Cargando...", color=ft.colors.GREY_600),
+        )
+
+        # Contenedor para mostrar las bicicletas disponibles para elegir
+        self.available_bikes_container = ft.Container(
+            padding=20,
+            content=ft.Text("Cargando bicicletas disponibles...", color=ft.colors.GREY_600),
+        )
+
+        # Botón para quitar bicicleta favorita
+        self.remove_favorite_button = ft.ElevatedButton(
+            text="Quitar Bicicleta Favorita",
+            icon=ft.icons.FAVORITE_BORDER,
+            color=ft.colors.RED,
+            on_click=self.remove_favorite_bike,
+            visible=False,
+        )
+
+        # Cargar datos iniciales
+        self.load_favorite_bike()
+        self.load_available_bikes()
+
+        return ft.Column(
+            [
+                ft.Container(height=20),
+                title,
+                ft.Container(height=10),
+                user_info,
+                ft.Container(height=20),
+                ft.Card(
+                    content=ft.Container(
+                        content=ft.Column(
+                            [
+                                ft.Text(
+                                    "Bicicleta Favorita Actual",
+                                    size=18,
+                                    weight=ft.FontWeight.BOLD,
+                                    color=ft.colors.BLUE_700,
+                                ),
+                                ft.Container(height=10),
+                                self.favorite_bike_container,
+                                self.remove_favorite_button,
+                            ]
+                        ),
+                        padding=20,
+                    ),
+                    elevation=4,
+                ),
+                ft.Container(height=20),
+                ft.Card(
+                    content=ft.Container(
+                        content=ft.Column(
+                            [
+                                ft.Text(
+                                    "Bicicletas Disponibles para Elegir",
+                                    size=18,
+                                    weight=ft.FontWeight.BOLD,
+                                    color=ft.colors.BLUE_700,
+                                ),
+                                ft.Container(height=10),
+                                ft.Text(
+                                    "Solo puedes elegir entre las bicicletas que has usado anteriormente:",
+                                    size=14,
+                                    color=ft.colors.GREY_600,
+                                ),
+                                ft.Container(height=10),
+                                self.available_bikes_container,
+                            ]
+                        ),
+                        padding=20,
+                    ),
+                    elevation=4,
+                ),
+            ],
+            scroll=ft.ScrollMode.AUTO,
+        )
+
+    def load_favorite_bike(self):
+        """Cargar la bicicleta favorita actual del usuario"""
+        if not self.current_user_cedula:
+            self.favorite_bike_container.content = ft.Text(
+                "No se pudo cargar la información del usuario",
+                color=ft.colors.RED,
+            )
+            self.app.page.update()
+            return
+
+        db = self.app.db
+        favorite_bike = FavoriteBikeService.get_user_favorite_bike_by_cedula(db, self.current_user_cedula)
+
+        if favorite_bike:
+            # Mostrar información de la bicicleta favorita
+            station_info = f"Estación: {favorite_bike.current_station.code} - {favorite_bike.current_station.name}" if favorite_bike.current_station else "Estación: No disponible"
+            
+            self.favorite_bike_container.content = ft.Column(
+                [
+                    ft.Row(
+                        [
+                            ft.Icon(ft.icons.FAVORITE, color=ft.colors.RED, size=24),
+                            ft.Text(
+                                f"Bicicleta {favorite_bike.bike_code}",
+                                size=16,
+                                weight=ft.FontWeight.BOLD,
+                                color=ft.colors.GREEN_700,
+                            ),
+                        ],
+                        spacing=10,
+                    ),
+                    ft.Text(f"Serie: {favorite_bike.serial_number}", size=14),
+                    ft.Text(station_info, size=14),
+                    ft.Text(f"Estado: {favorite_bike.status.value.title()}", size=14),
+                ],
+                spacing=8,
+            )
+            self.remove_favorite_button.visible = True
+        else:
+            # No tiene bicicleta favorita
+            self.favorite_bike_container.content = ft.Column(
+                [
+                    ft.Icon(ft.icons.FAVORITE_BORDER, color=ft.colors.GREY, size=48),
+                    ft.Text(
+                        "No tienes una bicicleta favorita seleccionada",
+                        size=16,
+                        color=ft.colors.GREY_600,
+                    ),
+                    ft.Text(
+                        "Elige una de las bicicletas que has usado anteriormente",
+                        size=14,
+                        color=ft.colors.GREY_500,
+                    ),
+                ],
+                horizontal_alignment=ft.CrossAxisAlignment.CENTER,
+                spacing=10,
+            )
+            self.remove_favorite_button.visible = False
+
+        self.app.page.update()
+
+    def load_available_bikes(self):
+        """Cargar las bicicletas disponibles para elegir como favorita"""
+        if not self.current_user_cedula:
+            self.available_bikes_container.content = ft.Text(
+                "No se pudo cargar la información del usuario",
+                color=ft.colors.RED,
+            )
+            self.app.page.update()
+            return
+
+        db = self.app.db
+        used_bikes = FavoriteBikeService.get_bikes_used_by_user_cedula(db, self.current_user_cedula)
+        current_favorite = FavoriteBikeService.get_user_favorite_bike_by_cedula(db, self.current_user_cedula)
+
+        if not used_bikes:
+            self.available_bikes_container.content = ft.Column(
+                [
+                    ft.Icon(ft.icons.DIRECTIONS_BIKE, color=ft.colors.GREY, size=48),
+                    ft.Text(
+                        "No has usado ninguna bicicleta aún",
+                        size=16,
+                        color=ft.colors.GREY_600,
+                    ),
+                    ft.Text(
+                        "Necesitas usar una bicicleta antes de poder elegirla como favorita",
+                        size=14,
+                        color=ft.colors.GREY_500,
+                    ),
+                ],
+                horizontal_alignment=ft.CrossAxisAlignment.CENTER,
+                spacing=10,
+            )
+        else:
+            bike_cards = []
+            for bike in used_bikes:
+                # Verificar si la bicicleta ya es favorita de alguien
+                is_favorite_of_other = FavoriteBikeService.is_bike_favorite(db, bike.id)
+                is_current_favorite = current_favorite and current_favorite.id == bike.id
+                
+                # Determinar si se puede seleccionar
+                can_select = not is_favorite_of_other or is_current_favorite
+                
+                # Información de la estación
+                station_info = f"Estación: {bike.current_station.code} - {bike.current_station.name}" if bike.current_station else "Estación: No disponible"
+                
+                # Estado del botón
+                button_text = "Ya es tu favorita" if is_current_favorite else "Elegir como favorita"
+                button_color = ft.colors.GREEN if is_current_favorite else ft.colors.BLUE
+                button_disabled = not can_select or is_current_favorite
+                
+                # Mensaje de estado
+                status_text = ""
+                if is_current_favorite:
+                    status_text = "✓ Tu bicicleta favorita"
+                elif is_favorite_of_other:
+                    status_text = "✗ Favorita de otro usuario"
+                else:
+                    status_text = "Disponible para elegir"
+
+                card = ft.Card(
+                    content=ft.Container(
+                        content=ft.Column(
+                            [
+                                ft.Row(
+                                    [
+                                        ft.Icon(ft.icons.DIRECTIONS_BIKE, color=ft.colors.BLUE_700, size=24),
+                                        ft.Text(
+                                            f"Bicicleta {bike.bike_code}",
+                                            size=16,
+                                            weight=ft.FontWeight.BOLD,
+                                        ),
+                                    ],
+                                    spacing=10,
+                                ),
+                                ft.Text(f"Serie: {bike.serial_number}", size=14),
+                                ft.Text(station_info, size=14),
+                                ft.Text(f"Estado: {bike.status.value.title()}", size=14),
+                                ft.Text(status_text, size=12, color=ft.colors.GREY_600),
+                                ft.Container(height=10),
+                                ft.ElevatedButton(
+                                    text=button_text,
+                                    icon=ft.icons.FAVORITE if is_current_favorite else ft.icons.FAVORITE_BORDER,
+                                    color=button_color,
+                                    disabled=button_disabled,
+                                    on_click=lambda e, b=bike: self.set_favorite_bike(b) if not is_current_favorite else None,
+                                ),
+                            ],
+                            spacing=8,
+                        ),
+                        padding=15,
+                    ),
+                    elevation=2,
+                )
+                bike_cards.append(card)
+
+            self.available_bikes_container.content = ft.Column(
+                bike_cards,
+                spacing=10,
+            )
+
+        self.app.page.update()
+
+    def set_favorite_bike(self, bike):
+        """Establecer una bicicleta como favorita"""
+        if not self.current_user_cedula:
+            return
+
+        db = self.app.db
+        success = FavoriteBikeService.set_favorite_bike_by_cedula(db, self.current_user_cedula, bike.id)
+
+        if success:
+            # Mostrar mensaje de éxito
+            self.app.page.show_snack_bar(
+                ft.SnackBar(
+                    content=ft.Text(f"¡Bicicleta {bike.bike_code} establecida como favorita!"),
+                    action="OK",
+                    action_color=ft.colors.GREEN,
+                )
+            )
+            # Recargar datos
+            self.load_favorite_bike()
+            self.load_available_bikes()
+        else:
+            # Mostrar mensaje de error
+            self.app.page.show_snack_bar(
+                ft.SnackBar(
+                    content=ft.Text("No se pudo establecer la bicicleta como favorita. Verifica que no sea favorita de otro usuario."),
+                    action="OK",
+                    action_color=ft.colors.RED,
+                )
+            )
+
+    def remove_favorite_bike(self, e):
+        """Quitar la bicicleta favorita actual"""
+        if not self.current_user_cedula:
+            return
+
+        db = self.app.db
+        success = FavoriteBikeService.remove_favorite_bike_by_cedula(db, self.current_user_cedula)
+
+        if success:
+            # Mostrar mensaje de éxito
+            self.app.page.show_snack_bar(
+                ft.SnackBar(
+                    content=ft.Text("Bicicleta favorita removida exitosamente"),
+                    action="OK",
+                    action_color=ft.colors.GREEN,
+                )
+            )
+            # Recargar datos
+            self.load_favorite_bike()
+            self.load_available_bikes()
+        else:
+            # Mostrar mensaje de error
+            self.app.page.show_snack_bar(
+                ft.SnackBar(
+                    content=ft.Text("No se pudo remover la bicicleta favorita"),
+                    action="OK",
+                    action_color=ft.colors.RED,
+                )
+            ) 

--- a/Proyecto/views/loan.py
+++ b/Proyecto/views/loan.py
@@ -20,6 +20,7 @@ from services import (
     BicycleService,
     StationService,
     LoanService,
+    FavoriteBikeService,
 )
 
 from .base import View
@@ -148,29 +149,53 @@ class LoanView(View):
         CARD_W, CARD_H = 110, 110  # un poco más grande y legible
 
         for bike in available_bikes:
+            # Verificar si la bicicleta es favorita de alguien
+            is_favorite = FavoriteBikeService.is_bike_favorite(db, bike.id)
+            favorite_owner = None
+            if is_favorite:
+                favorite_owner = FavoriteBikeService.get_favorite_bike_owner(db, bike.id)
+            
+            # Crear tooltip con información adicional
+            tooltip_text = f"Serie: {bike.serial_number}"
+            if is_favorite and favorite_owner:
+                tooltip_text += f"\nFavorita de: {favorite_owner.full_name}"
+            
+            # Color de fondo según si es favorita
+            bg_color = ft.colors.PINK_50 if is_favorite else ft.colors.GREY_100
+            
             card = ft.Card(
                 elevation=1,
                 content=ft.Container(
                     width=CARD_W,
                     height=CARD_H,
-                    bgcolor=ft.colors.GREY_100,
+                    bgcolor=bg_color,
                     border_radius=8,
                     padding=8,
                     alignment=ft.alignment.center,
                     on_click=_make_bike_select_handler(bike.bike_code),
                     content=ft.Column(
                         [
-                            ft.Icon(ft.icons.DIRECTIONS_BIKE, size=24, color=ft.colors.BLUE_700),
+                            ft.Icon(
+                                ft.icons.FAVORITE if is_favorite else ft.icons.DIRECTIONS_BIKE, 
+                                size=24, 
+                                color=ft.colors.RED if is_favorite else ft.colors.BLUE_700
+                            ),
                             ft.Text(
                                 bike.bike_code,
                                 weight=ft.FontWeight.BOLD,
                                 size=13,
                             ),
+                            ft.Text(
+                                "Favorita" if is_favorite else "",
+                                size=10,
+                                color=ft.colors.RED if is_favorite else ft.colors.TRANSPARENT,
+                                weight=ft.FontWeight.BOLD,
+                            ),
                         ],
                         horizontal_alignment=ft.CrossAxisAlignment.CENTER,
-                        spacing=4,
+                        spacing=2,
                     ),
-                    tooltip=f"Serie: {bike.serial_number}",
+                    tooltip=tooltip_text,
                     ink=True,
                 ),
             )


### PR DESCRIPTION
Ahora los usuarios pueden elegir una bicicleta favorita entre las que han usado anteriormente en el sistema VeciRun.
🎯 ¿Cómo funciona?
Para Usuarios Regulares:
Ve a "Mi Favorita" en el menú lateral
Elige una bicicleta de las que has usado antes
Ve dónde está tu bicicleta favorita en tu perfil
Para Administradores:
Al hacer préstamos verás qué bicicletas son favoritas de otros usuarios
Las bicicletas favoritas aparecen con un ❤️ y fondo rosado
Pasa el mouse sobre ellas para ver de quién es favorita
�� Reglas Importantes:
✅ Solo una bicicleta favorita por usuario
✅ Solo puedes elegir bicicletas que hayas usado antes
✅ Una bicicleta no puede ser favorita de dos usuarios al mismo tiempo
✅ Puedes cambiar tu bicicleta favorita cuando quieras
🎨 ¿Qué verás?
En tu perfil: Ubicación y estado de tu bicicleta favorita
Al elegir favorita: Lista de bicicletas que has usado
Para administradores: Indicadores visuales de bicicletas favoritas
💡 Beneficios:
Personalización: Cada usuario tiene su bicicleta preferida
Información clara: Sabes dónde está tu bicicleta favorita
Mejor gestión: Los administradores conocen las preferencias
Uso justo: Sistema organizado para evitar conflictos
¡Ahora puedes tener tu bicicleta favorita en VeciRun! 🚲❤