### PR TITLE
Generar y Aplicar Sanciones

### DIFF
--- a/Proyecto/tests/test_sanction_rules.py
+++ b/Proyecto/tests/test_sanction_rules.py
@@ -1,0 +1,256 @@
+import pytest
+import flet as ft
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from datetime import datetime, timedelta, timezone
+
+from models import (
+    Base,
+    User,
+    Station,
+    Bicycle,
+    BikeStatusEnum,
+    UserAffiliationEnum,
+    UserRoleEnum,
+    Sanction,
+    SanctionStatusEnum,
+    ReturnReport,
+    LoanStatusEnum,
+)
+
+from services import UserService, StationService, BicycleService, LoanService
+from views.return_report_view import ReturnReportView
+
+# ---------------------------------------------------------------------------
+# Helper stubs & utilities
+# ---------------------------------------------------------------------------
+
+# Stub ElevatedButton to avoid Flet runtime requirements in headless tests
+class _DummyElevatedButton:  # noqa: D101
+    last_callback = None
+
+    def __init__(self, *_, on_click=None, **__):  # noqa: D401
+        self.on_click = on_click
+        _DummyElevatedButton.last_callback = on_click
+
+# Patch once imported
+ft.ElevatedButton = _DummyElevatedButton  # type: ignore
+
+
+def _create_station(db, code: str) -> Station:  # noqa: D401
+    st = Station(code=code, name=f"Estación {code}")
+    db.add(st)
+    db.commit()
+    db.refresh(st)
+    return st
+
+
+def _create_bike(db, serial: str, code: str, station: Station | None = None) -> Bicycle:  # noqa: D401
+    bike = Bicycle(serial_number=serial, bike_code=code, status=BikeStatusEnum.disponible)
+    if station:
+        bike.current_station_id = station.id
+    db.add(bike)
+    db.commit()
+    db.refresh(bike)
+    return bike
+
+
+class _DummyPage:  # noqa: D101
+    def update(self):
+        pass
+
+    def window_to_front(self):
+        pass
+
+
+class _DummyApp:  # noqa: D101
+    def __init__(self, db_session):
+        self.db = db_session
+        self.page = _DummyPage()
+        self.content_area = type("_", (), {"content": None})()
+        # atributos de estado que usan las vistas
+        self.current_user_role = None
+        self.current_user_station = None
+        self.current_user = None
+
+    def clear_user_state(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="function")
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests – Loan sanction restrictions
+# ---------------------------------------------------------------------------
+
+def test_create_loan_fails_when_user_has_active_sanction(db_session):  # noqa: D401
+    """LoanService.create_loan debe lanzar ValueError si el usuario tiene una sanción activa."""
+
+    # Crear datos mínimos
+    user = UserService.create_user(
+        db_session,
+        cedula="1111",
+        carnet="",
+        full_name="Usuario Sancionado",
+        email="u@example.com",
+        affiliation=UserAffiliationEnum.estudiante,
+        role=UserRoleEnum.usuario,
+    )
+
+    station = _create_station(db_session, "EST001")
+    bike = _create_bike(db_session, "SER1", "B001")
+
+    # Crear sanción activa: hoy dentro del rango
+    now = datetime.utcnow()
+    sanction = Sanction(
+        user_id=user.id,
+        incident_id=None,  # Para pruebas no necesitamos incidente real
+        operator_id=None,
+        start_at=now - timedelta(days=1),
+        end_at=now + timedelta(days=2),
+        status=SanctionStatusEnum.activa,
+    )
+    db_session.add(sanction)
+    db_session.commit()
+
+    # Intentar crear préstamo
+    with pytest.raises(ValueError):
+        LoanService.create_loan(
+            db_session,
+            user_id=user.id,
+            bike_id=bike.id,
+            station_out_id=station.id,
+            station_in_id=station.id,
+        )
+
+
+def test_create_loan_when_sanction_expired_is_allowed(db_session):  # noqa: D401
+    """Si la sanción está expirada (fecha fin pasada), debe permitir el préstamo."""
+    user = UserService.create_user(
+        db_session,
+        cedula="2222",
+        carnet="",
+        full_name="Usuario Libre",
+        email="x@example.com",
+        affiliation=UserAffiliationEnum.estudiante,
+        role=UserRoleEnum.usuario,
+    )
+
+    station = _create_station(db_session, "EST002")
+    bike = _create_bike(db_session, "SER2", "B002")
+
+    past_sanction = Sanction(
+        user_id=user.id,
+        incident_id=None,
+        operator_id=None,
+        start_at=datetime.utcnow() - timedelta(days=10),
+        end_at=datetime.utcnow() - timedelta(days=5),
+        status=SanctionStatusEnum.expirada,
+    )
+    db_session.add(past_sanction)
+    db_session.commit()
+
+    # No debería lanzar excepción
+    loan = LoanService.create_loan(
+        db_session,
+        user_id=user.id,
+        bike_id=bike.id,
+        station_out_id=station.id,
+        station_in_id=station.id,
+    )
+    assert loan.status == LoanStatusEnum.abierto
+
+
+# ---------------------------------------------------------------------------
+# Tests – ReturnReportView filtrado por estación
+# ---------------------------------------------------------------------------
+
+def _count_cards(ctrl):  # noqa: D401
+    import flet as _ft
+    cards = []
+    if isinstance(ctrl, _ft.Card):
+        cards.append(ctrl)
+    for attr in ("controls", "content"):
+        if hasattr(ctrl, attr):
+            child = getattr(ctrl, attr)
+            if child is None:
+                continue
+            if isinstance(child, list):
+                for c in child:
+                    cards.extend(_count_cards(c))
+                
+            else:
+                cards.extend(_count_cards(child))
+    return cards
+
+
+def test_return_report_view_filters_by_admin_station(db_session):  # noqa: D401
+    """El administrador sólo debe ver reportes asociados a su estación."""
+
+    # Preparar datos
+    station1 = _create_station(db_session, "EST001")
+    station2 = _create_station(db_session, "EST002")
+
+    bike1 = _create_bike(db_session, "SER10", "B010")
+    bike2 = _create_bike(db_session, "SER20", "B020")
+
+    # Crear usuario y préstamos con reportes
+    user = UserService.create_user(
+        db_session,
+        cedula="3333",
+        carnet="",
+        full_name="User Report",
+        email="r@example.com",
+        affiliation=UserAffiliationEnum.estudiante,
+        role=UserRoleEnum.usuario,
+    )
+
+    # Loan associated to station1 (out)
+    loan1 = LoanService.create_loan(
+        db_session,
+        user_id=user.id,
+        bike_id=bike1.id,
+        station_out_id=station1.id,
+        station_in_id=station2.id,
+    )
+
+    # Loan associated to station2 (out) – should be hidden for admin of station1
+    loan2 = LoanService.create_loan(
+        db_session,
+        user_id=user.id,
+        bike_id=bike2.id,
+        station_out_id=station2.id,
+        station_in_id=station2.id,
+    )
+
+    # Crear reportes de devolución básicos
+    rr1 = ReturnReport(loan_id=loan1.id, total_incident_days=0, created_by=user.id)
+    rr2 = ReturnReport(loan_id=loan2.id, total_incident_days=0, created_by=user.id)
+    db_session.add_all([rr1, rr2])
+    db_session.commit()
+
+    # Configurar app como admin de station1
+    app = _DummyApp(db_session)
+    app.current_user_role = "admin"
+    app.current_user_station = "EST001"
+
+    view = ReturnReportView(app)
+    control = view.build()
+
+    cards = _count_cards(control)
+
+    assert len(cards) == 1, "El administrador debe ver sólo los reportes de su estación" 

--- a/Proyecto/views/loan.py
+++ b/Proyecto/views/loan.py
@@ -255,13 +255,18 @@ class LoanView(View):
                 return
 
             # Registrar préstamo
-            LoanService.create_loan(
-                db,
-                user_id=user.id,
-                bike_id=bike.id,
-                station_out_id=st_out.id,
-                station_in_id=st_in.id,
-            )
+            try:
+                LoanService.create_loan(
+                    db,
+                    user_id=user.id,
+                    bike_id=bike.id,
+                    station_out_id=st_out.id,
+                    station_in_id=st_in.id,
+                )
+            except ValueError as exc:
+                _set_result(str(exc), ft.colors.RED)
+                return
+
             _set_result("Préstamo registrado exitosamente", ft.colors.GREEN)
             # Limpiar campos
             user_cedula.value = ""

--- a/Proyecto/views/return_report_view.py
+++ b/Proyecto/views/return_report_view.py
@@ -27,6 +27,21 @@ class ReturnReportView:
             .order_by(ReturnReport.created_at.desc())
             .all()
         )
+
+        # ------------------------------------------------------------------
+        # Filtrar reportes por estación cuando el usuario es administrador
+        # ------------------------------------------------------------------
+        current_role = getattr(self.app, "current_user_role", None)
+        if current_role == "admin":
+            station_code = getattr(self.app, "current_user_station", None)
+            if station_code:
+                reports = [
+                    r for r in reports
+                    if (
+                        (r.loan.station_in and r.loan.station_in.code == station_code)
+                        or (r.loan.station_out and r.loan.station_out.code == station_code)
+                    )
+                ]
         
         if not reports:
             return ft.Column([
@@ -55,6 +70,30 @@ class ReturnReportView:
                 severity_enum = IncidentService.SEVERITY_INT_TO_ENUM.get(
                     incident.severity, IncidentSeverityEnum.leve
                 )
+
+                # Verificar si ya existe una sanción para este incidente
+                from models import Sanction
+                existing_sanction = (
+                    self.app.db.query(Sanction)
+                    .filter(Sanction.incident_id == incident.id)
+                    .first()
+                )
+
+                # Definir el botón según exista o no la sanción
+                if existing_sanction:
+                    sanction_button = ft.ElevatedButton(
+                        text="Ver Sanción",
+                        icon=ft.icons.VISIBILITY,
+                        on_click=lambda _e, sanc=existing_sanction: self._view_sanction(sanc),
+                        style=ft.ButtonStyle(padding=ft.padding.symmetric(horizontal=10, vertical=4)),
+                    )
+                else:
+                    sanction_button = ft.ElevatedButton(
+                        text="Generar Sanción",
+                        icon=ft.icons.GAVEL,
+                        on_click=lambda _e, inc=incident: self._generate_sanction(inc),
+                        style=ft.ButtonStyle(padding=ft.padding.symmetric(horizontal=10, vertical=4)),
+                    )
                 
                 incident_item = ft.Container(
                     content=ft.Column([
@@ -65,6 +104,7 @@ class ReturnReportView:
                             ft.Text(f"{severity_days} días", size=12, color=ft.colors.BLUE),
                         ]),
                         ft.Text(incident.description, size=11, color=ft.colors.GREY_600),
+                        sanction_button,
                     ]),
                     padding=ft.padding.all(8),
                     border=ft.border.all(1, ft.colors.GREY_300),
@@ -102,6 +142,20 @@ class ReturnReportView:
                             ft.Column([
                                 ft.Text("Bicicleta:", weight=ft.FontWeight.BOLD, size=12),
                                 ft.Text(report.loan.bike.bike_code, size=12),
+                            ], expand=True),
+                            ft.Column([
+                                ft.Text("Est. Salida:", weight=ft.FontWeight.BOLD, size=12),
+                                ft.Text(
+                                    f"{report.loan.station_out.code} - {report.loan.station_out.name}" if report.loan.station_out else "-",
+                                    size=12,
+                                ),
+                            ], expand=True),
+                            ft.Column([
+                                ft.Text("Est. Llegada:", weight=ft.FontWeight.BOLD, size=12),
+                                ft.Text(
+                                    f"{report.loan.station_in.code} - {report.loan.station_in.name}" if report.loan.station_out else "-",
+                                    size=12,
+                                ),
                             ], expand=True),
                             ft.Column([
                                 ft.Text("Fecha:", weight=ft.FontWeight.BOLD, size=12),
@@ -146,6 +200,85 @@ class ReturnReportView:
                 expand=True,
             ),
         ], expand=True, scroll=ft.ScrollMode.AUTO, spacing=10)
+
+    def _generate_sanction(self, incident):
+        """Genera una sanción básica para el incidente proporcionado y muestra confirmación"""
+        from models import Sanction
+        from datetime import datetime, timedelta
+
+        # Calcular duración en días basado en severidad
+        days = IncidentService.SEVERITY_DAYS.get(incident.severity, 0)
+        if days == 0:
+            # No se requiere sanción si la severidad no está mapeada
+            self.app.page.snack_bar = ft.SnackBar(
+                content=ft.Text("La severidad del incidente no requiere sanción."),
+                open=True,
+            )
+            self.app.page.update()
+            return
+
+        # Crear la sanción en la base de datos
+        operator_uuid = None
+        current_user_obj = getattr(self.app, "current_user", None)
+        if current_user_obj is not None:
+            operator_uuid = current_user_obj.id
+
+        sanction = Sanction(
+            user_id=incident.loan.user_id,
+            incident_id=incident.id,
+            operator_id=operator_uuid,
+            start_at=datetime.utcnow(),
+            end_at=datetime.utcnow() + timedelta(days=days),
+        )
+        self.app.db.add(sanction)
+        self.app.db.commit()
+
+        # Refrescar la vista para que el botón cambie a "Ver Sanción"
+        self.app.content_area.content = self.build()
+        self.app.page.update()
+
+        # Mostrar información de la sanción recién creada
+        self._view_sanction(sanction)
+
+    def _view_sanction(self, sanction):
+        """Muestra un diálogo con los detalles de la sanción"""
+        import datetime as _dt
+
+        def _close(_):
+            dialog.open = False
+            self.app.page.update()
+
+        status_text = sanction.status.value if hasattr(sanction.status, "value") else str(sanction.status)
+
+        # Obtener datos del usuario para mostrar nombre y cédula
+        user_obj = getattr(sanction, "user", None)
+        if user_obj is None:
+            from models import User
+            user_obj = self.app.db.query(User).filter(User.id == sanction.user_id).first()
+
+        user_line = "Desconocido"
+        if user_obj is not None:
+            user_line = f"{user_obj.full_name} (CC {user_obj.cedula})"
+
+        dialog = ft.AlertDialog(
+            modal=True,
+            title=ft.Text("Detalle de Sanción"),
+            content=ft.Column([
+                ft.Text(f"Usuario: {user_line}"),
+                ft.Text(f"Incidente ID: {sanction.incident_id}"),
+                ft.Text(f"Inicio: {sanction.start_at.strftime('%d/%m/%Y %H:%M') if sanction.start_at else ''}"),
+                ft.Text(f"Fin: {sanction.end_at.strftime('%d/%m/%Y %H:%M') if sanction.end_at else ''}"),
+                ft.Text(f"Estado: {status_text}"),
+            ], tight=True, spacing=5),
+            actions=[
+                ft.TextButton("Cerrar", on_click=_close),
+            ],
+            actions_alignment=ft.MainAxisAlignment.END,
+        )
+
+        self.app.page.dialog = dialog
+        dialog.open = True
+        self.app.page.update()
 
     def show(self):
         """Muestra la vista de reportes"""


### PR DESCRIPTION
Se implementó
- Botón de Generar Sanción, desde un incidente en la vista de reportes
- Aplicar Sanción: un usuario ya no puede pedir un préstamo si tiene una sanción activa