### PR TITLE
feat: estrellas en dashboard para la aplicación 

### DIFF
--- a/Proyecto/models.py
+++ b/Proyecto/models.py
@@ -101,6 +101,7 @@ class User(Base):
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
     privilege = Column(Enum(PrivilegeTypeEnum))
     favorite_bike_id = Column(UUID(as_uuid=True), ForeignKey("bicycles.id"))
+    stars = Column(SmallInteger, default=3)  # ⭐ AGREGADO AQUÍ
 
     # Relationships
     loans = relationship("Loan", back_populates="user", foreign_keys="Loan.user_id")

--- a/Proyecto/populate_db.py
+++ b/Proyecto/populate_db.py
@@ -132,6 +132,7 @@ def populate_users(session: Session) -> None:
                     email=f"usuario{i + 1}@universidad.edu",
                     affiliation=UserAffiliationEnum.estudiante,
                     role=UserRoleEnum.usuario,
+                    stars=3,
                 )
             )
 

--- a/Proyecto/views/dashboard.py
+++ b/Proyecto/views/dashboard.py
@@ -41,6 +41,20 @@ class DashboardView(View):
             weight=ft.FontWeight.BOLD,
             color=ft.colors.BLUE_900,
         )
+        
+        # --- Visualización de estrellas de usuario (si está logueado) ---
+        stars_text = None
+        if getattr(self.app, "current_user", None):
+            user_stars = getattr(self.app.current_user, "stars", 3)  # Valor por defecto 3
+            print("DEBUG: El usuario tiene estrellas =", user_stars)
+            stars_icons = "★" * user_stars + "☆" * (5 - user_stars)
+            stars_text = ft.Text(
+                f"Calificación: {stars_icons} ({user_stars}/5)",
+                size=20,
+                color=ft.colors.AMBER_700,
+                weight=ft.FontWeight.BOLD,
+            )
+
 
         # --- Contenido según rol ---
         if role == "admin":
@@ -468,6 +482,7 @@ class DashboardView(View):
             [
                 ft.Container(height=20),
                 ft.Row([welcome_text, ft.Container(expand=True), logout_btn]),
+                stars_text if stars_text else ft.Container(),
                 ft.Container(height=20),
                 body_content,
             ],


### PR DESCRIPTION
Se implementó la visualización de la calificación de estrellas para cada usuario en el dashboard, usando la columna stars de la base de datos. Esto permite mostrar una representación visual de la reputación del usuario directamente en la interfaz principal.